### PR TITLE
fix: replace curl Trivy install with pinned trivy-action@v0.36.0

### DIFF
--- a/.github/workflows/universal-dependency-track.yml
+++ b/.github/workflows/universal-dependency-track.yml
@@ -120,15 +120,17 @@ jobs:
           echo "✅ Dependency installation complete"
         continue-on-error: true
 
-      - name: Install Trivy
-        run: |
-          curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin
-
       - name: Generate SBOM with Trivy
-        run: |
-          echo "🔍 Scanning repository for dependencies and licenses..."
-          trivy fs --format cyclonedx --scanners license --license-full . -o bom-raw.json
+        uses: aquasecurity/trivy-action@v0.36.0
+        with:
+          scan-type: fs
+          format: cyclonedx
+          output: bom-raw.json
+          scanners: license
+          license-full: true
 
+      - name: Clean and prepare SBOM
+        run: |
           echo "🧹 Cleaning SBOM (removing lock files and false positives)..."
           cat bom-raw.json | jq '
             .components |= map(select(


### PR DESCRIPTION
## Summary

- Removes the unpinned `curl` install script (installs whatever Trivy version is current at run time)
- Replaces it with `aquasecurity/trivy-action@v0.36.0`, which bundles Trivy **v0.70.0** — the last known-good version before the v0.71.0 breaking change
- Splits the monolithic "Generate SBOM" step into two: one for the Trivy scan (action) and one for the `jq` cleanup

## Background

On 2026-06-02, Trivy v0.71.0 changed its CycloneDX output structure, producing a malformed BOM that Dependency-Track rejects with **HTTP 400**.

## Version mapping

| trivy-action | Trivy bundled | Status |
|---|---|---|
| `v0.36.0` | `v0.70.0` | ✅ Working |
| `v0.37.0+` | `v0.71.0+` | ⚠️ Broken |

## Test plan

- [ ] Trigger the workflow manually (`workflow_dispatch`) after merge and confirm the BOM upload returns 2xx

🤖 Generated with [Claude Code](https://claude.com/claude-code)