### PR TITLE
fix: run the Python test runner from any directory and keep result rows aligned

### DIFF
--- a/python/Testing/Test_Here_Maps.py
+++ b/python/Testing/Test_Here_Maps.py
@@ -234,12 +234,17 @@ def get_rates_from_tollguru(polyline, loc_times=None, vehicle_type="2AxlesAuto")
 from csv import reader, writer
 import time
 
+# Resolve the test case files next to this script, so the runner works from any
+# working directory (the README runs it as `python Testing/Test_Here_Maps.py`)
+TEST_CASES_FILE = Path(__file__).parent / "testCases.csv"
+RESULT_FILE = Path(__file__).parent / "testCases_result.csv"
+
 print("=" * 60)
 print("Starting toll calculation tests...")
 print("=" * 60)
 
 temp_list = []
-with open("testCases.csv", "r") as f:
+with open(TEST_CASES_FILE, "r") as f:
     csv_reader = reader(f)
     for count, i in enumerate(csv_reader):
         # if count>2:
@@ -255,6 +260,10 @@ with open("testCases.csv", "r") as f:
             )
         else:
             print(f"\n[Test {count}] {i[1]} → {i[2]}")
+
+            # Reset per test case, so a failed route never reuses the previous one
+            polyline = None
+            loc_times = None
 
             try:
                 # Get vehicle type from CSV (index 4), default to 2AxlesAuto if not provided
@@ -288,19 +297,21 @@ with open("testCases.csv", "r") as f:
             except Exception as e:
                 print(f"  ❌ Routing Error: {e}")
                 i.append("Routing Error")
-                loc_times = None
 
             start = time.time()
-            try:
-                # Pass locTimes and vehicle_type to Tollguru API
-                rates = get_rates_from_tollguru(polyline, loc_times, vehicle_type)
-            except Exception as e:
-                i.append(False)
-                rates = {}
+            rates = {}
+            # Without a polyline for this route there is nothing to price
+            if polyline is not None:
+                try:
+                    # Pass locTimes and vehicle_type to Tollguru API
+                    rates = get_rates_from_tollguru(polyline, loc_times, vehicle_type)
+                except Exception as e:
+                    rates = {}
             time_taken = time.time() - start
 
             if rates == {}:
-                i.append((None, None))
+                # Two cells, one per cost column, to stay aligned with the header
+                i.extend((None, None))
             else:
                 try:
                     tag = rates["tag"]
@@ -316,12 +327,12 @@ with open("testCases.csv", "r") as f:
         # print(f"{len(i)}   {i}\n")
         temp_list.append(i)
 
-with open("testCases_result.csv", "w") as f:
+with open(RESULT_FILE, "w") as f:
     writer(f).writerows(temp_list)
 
 print("\n" + "=" * 60)
 print(f"Testing complete! Processed {len(temp_list) - 1} test cases.")
-print(f"Results saved to: testCases_result.csv")
+print(f"Results saved to: {RESULT_FILE}")
 print("=" * 60)
 
 """Testing Ends"""

--- a/python/Testing/Test_Runner_Regression.py
+++ b/python/Testing/Test_Runner_Regression.py
@@ -1,0 +1,167 @@
+# Regression tests for the Test_Here_Maps.py runner
+#
+# The runner is executed end to end against a stubbed `requests` module, so
+# these tests need no HERE Maps / TollGuru API keys and make no network calls:
+#
+#     cd python && python Testing/Test_Runner_Regression.py
+
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from csv import reader
+from pathlib import Path
+
+TESTING_DIR = Path(__file__).resolve().parent
+
+# Addresses taken from testCases.csv: the second case is made to fail geocoding
+# and the third one is made to come back without tolls
+UNGEOCODABLE = "Burlington"
+TOLL_FREE = "Oklahoma City"
+
+# Stand-in for the `requests` package. Geocoding, routing and toll responses are
+# canned, so every branch of the runner can be exercised offline.
+REQUESTS_STUB = '''
+UNGEOCODABLE = "{ungeocodable}"
+TOLL_FREE = "{toll_free}"
+
+# A HERE flexible polyline for three points along the route
+FLEX_POLYLINE = "BF4n7zHv24qOoqwBwogBglkDwkiG"
+
+_state = {{"toll_free": False}}
+
+
+class _Response:
+    def __init__(self, payload, status_code=200):
+        self._payload = payload
+        self.status_code = status_code
+        self.text = str(payload)
+
+    def json(self):
+        return self._payload
+
+
+def get(url, params=None, **kwargs):
+    if "geocode" in url:
+        query = ((params or {{}}).get("q") or "") + url
+        if UNGEOCODABLE in query:
+            return _Response({{"items": []}})
+        if TOLL_FREE in query:
+            _state["toll_free"] = True
+        return _Response({{"items": [{{"position": {{"lat": 39.9526, "lng": -75.1652}}}}]}})
+
+    return _Response({{
+        "routes": [{{
+            "sections": [{{
+                "polyline": FLEX_POLYLINE,
+                "departure": {{"time": "2026-01-05T09:46:08+00:00"}},
+                "actions": [
+                    {{"offset": 0, "duration": 60}},
+                    {{"offset": 1, "duration": 120}},
+                ],
+            }}]
+        }}]
+    }})
+
+
+def post(url, json=None, headers=None, **kwargs):
+    toll_free = _state["toll_free"]
+    _state["toll_free"] = False
+    if toll_free:
+        return _Response({{"route": {{"costs": {{}}}}}})
+    return _Response({{"route": {{"costs": {{"tag": 1.25, "cash": 2.5}}}}}})
+'''.format(ungeocodable=UNGEOCODABLE, toll_free=TOLL_FREE)
+
+
+class TestRunner(unittest.TestCase):
+    """Runs Test_Here_Maps.py once and checks the CSV it produces"""
+
+    @classmethod
+    def setUpClass(cls):
+        cls._workspace = tempfile.TemporaryDirectory()
+        workspace = Path(cls._workspace.name)
+
+        # Work on a copy, so the checked in test cases and results are untouched
+        testing_copy = workspace / "python" / "Testing"
+        shutil.copytree(TESTING_DIR, testing_copy)
+
+        stub_dir = workspace / "stub"
+        stub_dir.mkdir()
+        (stub_dir / "requests.py").write_text(REQUESTS_STUB)
+
+        environment = dict(
+            os.environ,
+            PYTHONPATH=str(stub_dir),
+            HERE_API_KEY="stub-key",
+            TOLLGURU_API_KEY="stub-key",
+        )
+
+        # Start it the way the README does, from the python/ directory
+        cls.completed = subprocess.run(
+            [sys.executable, os.path.join("Testing", "Test_Here_Maps.py")],
+            cwd=workspace / "python",
+            env=environment,
+            capture_output=True,
+            text=True,
+        )
+        cls.result_file = testing_copy / "testCases_result.csv"
+
+    @classmethod
+    def tearDownClass(cls):
+        cls._workspace.cleanup()
+
+    def rows(self):
+        self.assertTrue(
+            self.result_file.exists(),
+            f"no results were written\n{self.completed.stdout}\n{self.completed.stderr}",
+        )
+        with open(self.result_file, "r") as f:
+            return list(reader(f))
+
+    def test_runs_from_the_python_directory(self):
+        """`python Testing/Test_Here_Maps.py` finds its test cases"""
+        self.assertEqual(
+            self.completed.returncode, 0, f"runner failed\n{self.completed.stderr}"
+        )
+
+    def test_every_row_has_a_cell_per_header_column(self):
+        """Result rows line up with the header, including toll free routes"""
+        rows = self.rows()
+        header = rows[0]
+        for row in rows[1:]:
+            self.assertEqual(
+                len(row), len(header), f"row {row[0]} does not match the header"
+            )
+
+    def test_toll_free_route_leaves_both_cost_columns_empty(self):
+        """A route without tolls writes a tag cell and a cash cell"""
+        rows = self.rows()
+        header = rows[0]
+        tag = header.index("Tollguru_Tag_Cost")
+        cash = header.index("Tollguru_Cash_Cost")
+
+        toll_free_rows = [row for row in rows[1:] if TOLL_FREE in row[1]]
+        self.assertTrue(toll_free_rows, "no toll free test case was run")
+        for row in toll_free_rows:
+            self.assertEqual(row[tag], "")
+            self.assertEqual(row[cash], "")
+
+    def test_failed_route_is_not_priced_with_the_previous_polyline(self):
+        """A routing error leaves the costs empty instead of the last route's"""
+        rows = self.rows()
+        header = rows[0]
+        polyline = header.index("Input_polyline")
+        tag = header.index("Tollguru_Tag_Cost")
+        cash = header.index("Tollguru_Cash_Cost")
+
+        failed_rows = [row for row in rows[1:] if row[polyline] == "Routing Error"]
+        self.assertTrue(failed_rows, "no routing error test case was run")
+        for row in failed_rows:
+            self.assertEqual(row[tag], "", "costs of another route were reported")
+            self.assertEqual(row[cash], "", "costs of another route were reported")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR proposes fixing the Python test runner so it starts from the directory the README documents and so its result CSV never reports another route's tolls. We include this PR work along with a full history of your repo at https://eastagiletracker.com/projects/327. You can sign in with your GitHub ID to claim ownership of the project.

## What was wrong

`python/Testing/Test_Here_Maps.py` opens `testCases.csv` and `testCases_result.csv` relative to the current working directory. The README's "How to Run Tests" tells a Python user to `cd python && pip install -r requirements.txt` and then run `python Testing/Test_Here_Maps.py`, so on current `main` the first command a new user runs stops before a single test case executes:

```
$ cd python && python Testing/Test_Here_Maps.py
============================================================
Starting toll calculation tests...
============================================================
Traceback (most recent call last):
  File ".../python/Testing/Test_Here_Maps.py", line 242, in <module>
    with open("testCases.csv", "r") as f:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^
FileNotFoundError: [Errno 2] No such file or directory: 'testCases.csv'
```

Starting it from `python/Testing/` instead (where the relative paths happen to resolve) exposes two problems in the results it writes. `polyline` is never reset between test cases, so when the HERE Maps geocoding or routing step raises for one row, the TollGuru call that follows still runs — with the polyline left over from the previous row. That row is written out as `Routing Error` next to a tag and cash cost that belong to a different route. Separately, a route that genuinely has no tolls takes the `rates == {}` branch, which appends the tuple `(None, None)` as a single cell, leaving that row one column short of the header so the query time lands under `Tollguru_Cash_Cost`.

Here is `testCases_result.csv` on current `main`, with the HERE Maps and TollGuru responses stubbed so the three cases are deterministic (row 7 fails geocoding, row 9 routes fine but has no tolls):

```
header (9 cols): id, from, to, Region, VehicleType, Input_polyline, Tollguru_Tag_Cost, Tollguru_Cash_Cost, Tollguru_QueryTime_In_Sec
row id=4 (9 cols): ['wfzrFnuwiMgio@og_@_dcBocaE', '1.25', '2.5', '6.43e-06']
row id=7 (9 cols): ['Routing Error', '1.25', '2.5', '3.81e-06']      <- costs of row 4's route
row id=9 (8 cols): ['wfzrFnuwiMgio@og_@_dcBocaE', '(None, None)', '2.86e-06']
```

## What changed

Both CSV paths are now resolved from the script location, so the runner works from `python/` as documented (and from anywhere else). `polyline` and `loc_times` are reset at the top of each test case and the TollGuru call is skipped when routing produced no polyline, so a failed row can no longer inherit the previous route. The no-tolls branch writes two cells instead of one tuple, so every row lines up with the header. The CSV columns, their order and the successful-row values are unchanged; only the failed and toll-free rows change, from misleading values to empty cells.

`Testing/Test_Runner_Regression.py` is added alongside the runner. It executes `Testing/Test_Here_Maps.py` end to end from the `python/` directory against a stubbed `requests` module, so it needs no HERE Maps or TollGuru keys and makes no network calls:

```
$ cd python && python Testing/Test_Runner_Regression.py
Ran 4 tests in 0.06s

OK
```

Verified against a run of the same checks on unmodified `main`: `python -m compileall python` passed before and after, and the documented command went from exiting 1 with the traceback above to exiting 0 and writing 11 aligned rows. Each new test fails on the current runner for its own reason — with only the path change applied so the later rows are reachable, `test_every_row_has_a_cell_per_header_column` reports `8 != 9 : row 9 does not match the header`, `test_failed_route_is_not_priced_with_the_previous_polyline` reports `'1.25' != '' : costs of another route were reported`, and `test_toll_free_route_leaves_both_cost_columns_empty` reports `'(None, None)' != ''` — and all four pass with the fix.

The JavaScript and Ruby runners have the same working-directory assumption for `input.json` and `TestCases/testCases.csv`; they are left alone here to keep this change to one thing, and I am happy to follow up if that is useful.

## How this was managed

This work was tracked on a live agile board imported from this repository's own issues and pull requests (55 stories, 6 labels): the story for this fix is at https://eastagiletracker.com/projects/327/stories/210643 and the board is at https://eastagiletracker.com/projects/327.

![board](https://raw.githubusercontent.com/eastagiletracker/tolltally-toll-for-route-here-maps/agile-board-assets/board.png)

If you'd rather not receive contributions like this, reply `no-more-prs` on this pull request and we won't open any further ones on your repositories.

---

**Lawrence W. Sinclair**
CEO / East Agile
[linkedin.com/in/lwsinclair/](https://linkedin.com/in/lwsinclair/)
[eastagile.com](https://eastagile.com)
